### PR TITLE
fix outdated repo url

### DIFF
--- a/docs/source/FirstTimeQuickSetup.rst
+++ b/docs/source/FirstTimeQuickSetup.rst
@@ -34,7 +34,7 @@ First you will need to clone the galv repository using ``git``:
 
 .. code-block:: bash
 
-	git clone https://gitlab.com/battery-intelligence-lab/galv-project/galv.git
+	git clone https://github.com/Battery-Intelligence-Lab/galv.git
 	cd galv
 
 


### PR DESCRIPTION
docs are currently pointing to the wrong (private) repo
(But otherwise deployment works fine =)